### PR TITLE
Updated dependencies for python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,13 @@ websockets==12.0
 
 # Machine Learning & Audio Processing
 numpy==1.26.3
-onnxruntime==1.16.3
-transformers==4.37.2
+onnxruntime==1.23.2
+transformers==4.57.3
 
 # MLX Whisper (Apple Silicon optimized)
-mlx-whisper==0.3.1
-mlx==0.15.0
+mlx-whisper==0.4.3
+mlx==0.30.0
+kokoro==0.9.4
+
+# LMX LM Text Generation
+mlx-lm==0.29.1


### PR DESCRIPTION
Bumping some dependencies such that the project runs on Python3.12 (didn't test any other versions at this point).
With the original set of requirements I could not get a common denominator for python versions 3.9-3.14 that would run the code.

Love your project by the way!